### PR TITLE
Fix: properly handle recover in nested defer functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,14 +45,12 @@ func main() {
 		l.Close()
 	}()
 	defer func() {
-		defer func() {
-			if err := recover(); err != nil {
-				l.Error("Panic: %v", err)
-				buf := make([]byte, 1024)
-				n := runtime.Stack(buf, false)
-				l.Error("Stack trace: \n%s", buf[:n])
-			}
-		}()
+		if err := recover(); err != nil {
+			l.Error("Panic: %v", err)
+			buf := make([]byte, 1024)
+			n := runtime.Stack(buf, false)
+			l.Error("Stack trace: \n%s", buf[:n])
+		}
 	}()
 
 	logger.InitLogger(config.GetLogLevel(), config.GetLogFile())


### PR DESCRIPTION
修复嵌套 `defer` 函数中的 `recover` 无法正确捕获 `painc`

测试代码如下:

``` go
package main

import "fmt"

func main() {
	fmt.Println("testRecover")
	testRecover()

	fmt.Println("testNestedRecover")
	testNestedRecover()

	fmt.Println("main end")
}

func foo() {
	panic("foo panic")
}

func testRecover() {
	defer func() {
		if err := recover(); err != nil {
			fmt.Println("recover: ", err)
		}
	}()

	foo()

}

func testNestedRecover() {
	defer func() {
		defer func() {
			if err := recover(); err != nil {
				fmt.Println("recover: ", err)
			}
		}()
	}()

	foo()
}
```

运行结果:

``` bash
go run test_recover.go
testRecover
recover:  foo panic
testNestedRecover
panic: foo panic

goroutine 1 [running]:
main.foo(...)
        /Users/divinerapier/test_recover.go:16
main.testNestedRecover()
        /Users/divinerapier/test_recover.go:39 +0x4c
main.main()
        /Users/divinerapier/test_recover.go:10 +0x88
exit status 2
```

运行结果未按照期望输出 `main end`